### PR TITLE
优化ExComponentString

### DIFF
--- a/src/main/java/taskeren/extrabot/components/ExComponentString.java
+++ b/src/main/java/taskeren/extrabot/components/ExComponentString.java
@@ -10,10 +10,13 @@ import lombok.ToString;
  *
  * @author Taskeren
  */
-@ToString
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter
 public class ExComponentString extends ExComponent
 {
     final String message;
+
+    public String toString() {
+        return message;
+    }
 }


### PR DESCRIPTION
取消了ExComponentString的@ToString
直接将toString()内容改为原文