### PR TITLE
"图片"消息组件兼容发送本地路径的图片

### DIFF
--- a/src/main/java/cc/moecraft/icq/sender/message/components/ComponentImage.java
+++ b/src/main/java/cc/moecraft/icq/sender/message/components/ComponentImage.java
@@ -1,7 +1,6 @@
 package cc.moecraft.icq.sender.message.components;
 
 import cc.moecraft.icq.sender.message.MessageComponent;
-import lombok.AllArgsConstructor;
 
 /**
  * 此类由 Hykilpikonna 在 2018/05/26 创建!
@@ -11,14 +10,27 @@ import lombok.AllArgsConstructor;
  *
  * @author Hykilpikonna
  */
-@AllArgsConstructor
 public class ComponentImage extends MessageComponent
 {
     public String fileOrURL;
+    public boolean isLocalFile;
+
+    public ComponentImage(String fileOrURL) {
+        this.fileOrURL = fileOrURL;
+    }
+
+    public ComponentImage(String fileOrURL, boolean isLocalFile) {
+        this.fileOrURL = fileOrURL;
+        this.isLocalFile = isLocalFile;
+    }
 
     @Override
     public String toString()
     {
-        return "[CQ:image,file=" + fileOrURL + "]";
+        if (isLocalFile) {
+            return "[CQ:image,file=file:///" + fileOrURL + "]";
+        } else {
+            return "[CQ:image,file=" + fileOrURL + "]";
+        }
     }
 }

--- a/src/main/java/cc/moecraft/icq/sender/message/components/ComponentImageNoCache.java
+++ b/src/main/java/cc/moecraft/icq/sender/message/components/ComponentImageNoCache.java
@@ -15,9 +15,17 @@ public class ComponentImageNoCache extends ComponentImage
         super(fileOrURL);
     }
 
+    public ComponentImageNoCache(String fileOrURL, boolean isLocalFile) {
+        super(fileOrURL, isLocalFile);
+    }
+
     @Override
     public String toString()
     {
-        return "[CQ:image,cache=0,file=" + super.fileOrURL + "]";
+        if (isLocalFile) {
+            return "[CQ:image,cache=0,file=file:///" + super.fileOrURL + "]";
+        } else {
+            return "[CQ:image,cache=0,file=" + super.fileOrURL + "]";
+        }
     }
 }


### PR DESCRIPTION
调试的时候发现的bug，发现漏了`file:///`导致

参照
https://github.com/howmanybots/onebot/blob/master/v11/specs/message/segment.md#%E5%9B%BE%E7%89%87