### PR TITLE
事件新增、消息组件新增、若干bug修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ public class 类名随意 extends IcqListener // 必须继承 IcqListener 监听
 | EventNoticeFriendRecall | 好友消息撤回事件 |
 | EventNoticeGroupPoke | 群戳一戳事件 |
 | EventNoticeFriendPoke | 好友戳一戳事件 (go-cqhttp 拓展) |
+| EventNoticeGroupCard | 群成员名片更新事件 (go-cqhttp 拓展) |
+| EventNoticeGroupHonor | 群成员荣耀变更事件  |
+| EventNoticeGroupLuckyKing | 群红包运气王事件 |
 | EventRequest | 所有请求事件 |
 | EventFriendRequest | 加好友请求事件 |
 | EventGroupAddRequest | 加群请求事件 |

--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ icqHttpApi.封装方法名(参数); // 返回的就是响应数据啦w
 | .sendGroupMsg | 发送群聊消息 |
 | .sendDiscussMsg | 发送讨论组消息 |
 | .deleteMsg | 撤回消息 |
+| .getMsg | 获取消息 |
 | .sendLike | 好友点赞 |
 | .sendGroupNotice | 发送群公告 |
 | .setGroupKick | 飞机票 |
@@ -534,6 +535,7 @@ new MessageBuilder()
 | ComponentImageBase64 | Base64 编码图片组件 |
 | ComponentSFace | 小表情组件 |
 | ComponentShare | 分享链接组件 |
+| ComponentPoke | 群聊戳一戳组件 (适配 go-cqhttp, 与 OneBot 标准有差异) |
 | ComponentDice | 掷骰子组件 (只能单独发送) |
 | ComponentMusic | 音乐组件 (只能单独发送) |
 | ComponentRecord | 语音组件 (只能单独发送) |

--- a/src/main/java/cc/moecraft/icq/PicqConstants.java
+++ b/src/main/java/cc/moecraft/icq/PicqConstants.java
@@ -70,6 +70,7 @@ public class PicqConstants
     public static final String EVENT_KEY_NOTIFY_POKE = "poke";
     public static final String EVENT_KEY_NOTIFY_LUCKY_KING = "lucky_king";
     public static final String EVENT_KEY_NOTIFY_HONOR = "honor";
+    public static final String EVENT_KEY_NOTIFY_GROUP_CARD = "group_card";
 
     public static final String EVENT_KEY_META_TYPE = "meta_event_type";
     public static final String EVENT_KEY_META_TYPE_HEARTBEAT = "heartbeat";

--- a/src/main/java/cc/moecraft/icq/event/EventManager.java
+++ b/src/main/java/cc/moecraft/icq/event/EventManager.java
@@ -94,6 +94,9 @@ public class EventManager
             EventNoticeFriendRecall.class,
             EventNoticeGroupPoke.class,
             EventNoticeFriendPoke.class,
+            EventNoticeGroupLuckyKing.class,
+            EventNoticeGroupHonor.class,
+            EventNoticeGroupCard.class,
             EventNotice.class,
 
             EventFriendRequest.class,

--- a/src/main/java/cc/moecraft/icq/event/EventParser.java
+++ b/src/main/java/cc/moecraft/icq/event/EventParser.java
@@ -401,11 +401,20 @@ public class EventParser
                 call(event);
                 break;
             }
+            // 群成员名片变更
+            case EVENT_KEY_NOTIFY_GROUP_CARD: {
+                EventNoticeGroupCard event = gsonRead.fromJson(json, EventNoticeGroupCard.class);
+                if (isNew(event, event.getGroupId().toString())) {
+                    call(event);
+                }
+                break;
+            }
             case EVENT_KEY_NOTICE_TYPE_NOTIFY:
             {
                 String subtype = json.get(EVENT_KEY_SUBTYPE).getAsString();
                 switch (subtype)
                 {
+                    // 群戳一戳 & 好友戳一戳
                     case EVENT_KEY_NOTIFY_POKE:
                         // 此处根据 go-cqhttp 适配, 好友戳一戳和群里戳一戳的差别就在于有没有 group_id 这个字段。
                         if (json.has("group_id")) {
@@ -420,8 +429,22 @@ public class EventParser
                             call(event);
                         }
                         break;
-                    case EVENT_KEY_NOTIFY_LUCKY_KING: // todo 群红包运气王
-                    case EVENT_KEY_NOTIFY_HONOR: // todo 群成员荣誉变更
+                    // 群红包运气王
+                    case EVENT_KEY_NOTIFY_LUCKY_KING: {
+                        EventNoticeGroupLuckyKing event = gsonRead.fromJson(json, EventNoticeGroupLuckyKing.class);
+                        if (isNew(event, event.getGroupId().toString())) {
+                            call(event);
+                        }
+                        break;
+                    }
+                    // 群成员荣誉变更
+                    case EVENT_KEY_NOTIFY_HONOR: {
+                        EventNoticeGroupHonor event = gsonRead.fromJson(json, EventNoticeGroupHonor.class);
+                        if (isNew(event, event.getGroupId().toString())) {
+                            call(event);
+                        }
+                        break;
+                    }
                     default:
                         reportUnrecognized(EVENT_KEY_SUBTYPE, subtype, json);
                         break;

--- a/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupCard.java
+++ b/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupCard.java
@@ -1,0 +1,70 @@
+package cc.moecraft.icq.event.events.notice;
+
+import cc.moecraft.icq.user.Group;
+import cc.moecraft.icq.user.GroupUser;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import lombok.*;
+
+/**
+ * 群成员名片更新事件
+ * go-cqhttp 文档备注: 此事件不保证时效性, 仅在收到消息时校验卡片
+ *
+ * @author CrazyKid (i@crazykid.moe)
+ * @since 2021/3/31 09:51
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Setter(AccessLevel.NONE)
+@ToString(callSuper = true)
+public class EventNoticeGroupCard extends EventNotice {
+    /**
+     * 群号
+     */
+    @SerializedName("group_id")
+    @Expose
+    protected Long groupId;
+
+    /**
+     * 新名片 (当名片是空时, 为空字符串, 并不是QQ昵称)
+     */
+    @SerializedName("card_new")
+    @Expose
+    protected String cardNew;
+
+    /**
+     * 旧名片 (当名片是空时, 为空字符串, 并不是QQ昵称)
+     */
+    @SerializedName("card_old")
+    @Expose
+    protected String cardOld;
+
+    /**
+     * 获取群对象
+     *
+     * @return 群对象
+     */
+    public Group getGroup() {
+        return getBot().getGroupManager().getGroupFromID(groupId);
+    }
+
+    /**
+     * 获取群名片变更的群用户对象
+     *
+     * @return 群名片变更的群用户对象
+     */
+    public GroupUser getGroupUser() {
+        return getBot().getGroupUserManager().getUserFromID(userId, getGroup());
+    }
+
+    @Override
+    public boolean contentEquals(Object o) {
+        if (!(o instanceof EventNoticeGroupCard)) return false;
+        EventNoticeGroupCard other = (EventNoticeGroupCard) o;
+
+        return super.contentEquals(o) &&
+                other.getCardNew().equals(this.getCardNew()) &&
+                other.getCardOld().equals(this.getCardOld()) &&
+                other.getGroupId().equals(this.getGroupId());
+    }
+}

--- a/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupHonor.java
+++ b/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupHonor.java
@@ -1,0 +1,89 @@
+package cc.moecraft.icq.event.events.notice;
+
+import cc.moecraft.icq.user.Group;
+import cc.moecraft.icq.user.GroupUser;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import lombok.*;
+
+/**
+ * 群成员荣誉变更事件
+ *
+ * @author CrazyKid (i@crazykid.moe)
+ * @since 2021/3/31 09:33
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Setter(AccessLevel.NONE)
+@ToString(callSuper = true)
+public class EventNoticeGroupHonor extends EventNotice {
+    /**
+     * 群号
+     */
+    @SerializedName("group_id")
+    @Expose
+    protected Long groupId;
+
+    /**
+     * 荣誉类型
+     * talkative:龙王 performer:群聊之火 emotion:快乐源泉
+     */
+    @SerializedName("honor_type")
+    @Expose
+    protected String honorType;
+
+    /**
+     * 获取群对象
+     *
+     * @return 群对象
+     */
+    public Group getGroup() {
+        return getBot().getGroupManager().getGroupFromID(groupId);
+    }
+
+    /**
+     * 获取荣誉变更的群用户对象
+     *
+     * @return 荣誉变更的群用户对象
+     */
+    public GroupUser getGroupUser() {
+        return getBot().getGroupUserManager().getUserFromID(userId, getGroup());
+    }
+
+    /**
+     * 是否是龙王
+     *
+     * @return 是否是龙王
+     */
+    public boolean isDragonKing() {
+        return "talkative".equals(honorType);
+    }
+
+    /**
+     * 是否是群聊之火
+     *
+     * @return 是否是群聊之火
+     */
+    public boolean isPerformer() {
+        return "performer".equals(honorType);
+    }
+
+    /**
+     * 是否是快乐源泉
+     *
+     * @return 是否是快乐源泉
+     */
+    public boolean isEmotion() {
+        return "emotion".equals(honorType);
+    }
+
+    @Override
+    public boolean contentEquals(Object o) {
+        if (!(o instanceof EventNoticeGroupHonor)) return false;
+        EventNoticeGroupHonor other = (EventNoticeGroupHonor) o;
+
+        return super.contentEquals(o) &&
+                other.getHonorType().equals(this.getHonorType()) &&
+                other.getGroupId().equals(this.getGroupId());
+    }
+}

--- a/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupLuckyKing.java
+++ b/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupLuckyKing.java
@@ -1,0 +1,70 @@
+package cc.moecraft.icq.event.events.notice;
+
+import cc.moecraft.icq.user.Group;
+import cc.moecraft.icq.user.GroupUser;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import lombok.*;
+
+/**
+ * 群成员红包运气王事件
+ *
+ * @author CrazyKid (i@crazykid.moe)
+ * @since 2021/3/31 09:44
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Setter(AccessLevel.NONE)
+@ToString(callSuper = true)
+public class EventNoticeGroupLuckyKing extends EventNotice {
+    /**
+     * 群号
+     */
+    @SerializedName("group_id")
+    @Expose
+    protected Long groupId;
+
+    /**
+     * 运气王id
+     */
+    @SerializedName("target_id")
+    @Expose
+    protected Long targetId;
+
+    /**
+     * 获取群对象
+     *
+     * @return 群对象
+     */
+    public Group getGroup() {
+        return getBot().getGroupManager().getGroupFromID(groupId);
+    }
+
+    /**
+     * 获取红包发送者的群用户对象
+     *
+     * @return 红包发送者的群用户对象
+     */
+    public GroupUser getRedpackSenderGroupUser() {
+        return getBot().getGroupUserManager().getUserFromID(userId, getGroup());
+    }
+
+    /**
+     * 获取运气王的群用户对象
+     *
+     * @return 红包发送者的群用户对象
+     */
+    public GroupUser getLuckyKingGroupUser() {
+        return getBot().getGroupUserManager().getUserFromID(targetId, getGroup());
+    }
+
+    @Override
+    public boolean contentEquals(Object o) {
+        if (!(o instanceof EventNoticeGroupLuckyKing)) return false;
+        EventNoticeGroupLuckyKing other = (EventNoticeGroupLuckyKing) o;
+
+        return super.contentEquals(o) &&
+                other.getTargetId().equals(this.getTargetId()) &&
+                other.getGroupId().equals(this.getGroupId());
+    }
+}

--- a/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupRecall.java
+++ b/src/main/java/cc/moecraft/icq/event/events/notice/EventNoticeGroupRecall.java
@@ -103,7 +103,10 @@ public class EventNoticeGroupRecall extends EventNotice {
      */
     public String getMessage(boolean raw) {
         RMessage message = getHttpApi().getMsg(messageId).getData();
-        return raw ? message.getMessageRaw() : message.getMessage();
+        if (raw && message.getMessageRaw() != null) {
+            return message.getMessageRaw();
+        }
+        return message.getMessage();
     }
 
     @Override

--- a/src/main/java/cc/moecraft/icq/sender/IcqHttpApi.java
+++ b/src/main/java/cc/moecraft/icq/sender/IcqHttpApi.java
@@ -98,14 +98,15 @@ public class IcqHttpApi
      */
     public JsonElement send(HttpApiNode api, Map<String, Object> params)
     {
-        // 创建请求
-        HttpRequest request = HttpRequest.post(makeUrl(api)).body(new JSONObject(params).toString()).timeout(5000);
-
-        // 判断有没有 Access Token, 并加到头上w
+        String url = makeUrl(api);
+        // 判断有没有 Access Token, 并加到 Url 后
         if (!bot.getConfig().getAccessToken().isEmpty())
         {
-            request.header("Authorization", "Bearer " + bot.getConfig().getAccessToken());
+            url += "?access_token=" + bot.getConfig().getAccessToken();
         }
+
+        // 创建请求
+        HttpRequest request = HttpRequest.post(url).body(new JSONObject(params).toString()).timeout(5000);
 
         // 发送并返回
         return new JsonParser().parse(request.execute().body());

--- a/src/main/java/cc/moecraft/icq/sender/message/components/ComponentImage.java
+++ b/src/main/java/cc/moecraft/icq/sender/message/components/ComponentImage.java
@@ -15,8 +15,8 @@ public class ComponentImage extends MessageComponent
     public String fileOrURL;
     public boolean isLocalFile;
 
-    public ComponentImage(String fileOrURL) {
-        this.fileOrURL = fileOrURL;
+    public ComponentImage(String url) {
+        this.fileOrURL = url;
     }
 
     public ComponentImage(String fileOrURL, boolean isLocalFile) {

--- a/src/main/java/cc/moecraft/icq/sender/message/components/ComponentPoke.java
+++ b/src/main/java/cc/moecraft/icq/sender/message/components/ComponentPoke.java
@@ -1,0 +1,22 @@
+package cc.moecraft.icq.sender.message.components;
+
+import cc.moecraft.icq.sender.message.MessageComponent;
+import lombok.AllArgsConstructor;
+
+/**
+ * 戳一戳(仅限群聊)
+ * 注: 此类适配 go-cqhttp, 与 OneBot 标准略有差异
+ *
+ * @author CrazyKid (i@crazykid.moe)
+ * @since 2020/3/31 10:43
+ */
+@AllArgsConstructor
+public class ComponentPoke extends MessageComponent {
+
+    private final Long qq;
+
+    @Override
+    public String toString() {
+        return "[CQ:poke,qq=" + qq + "]";
+    }
+}

--- a/src/main/java/cc/moecraft/icq/sender/returndata/returnpojo/get/RMessage.java
+++ b/src/main/java/cc/moecraft/icq/sender/returndata/returnpojo/get/RMessage.java
@@ -76,6 +76,9 @@ public class RMessage implements ReturnPojoBase {
     }
 
     public String getMessageRaw() {
+        if (messageRaw == null) {
+            return null;
+        }
         return CQUtils.decodeMessage(messageRaw);
     }
 

--- a/src/main/java/cc/moecraft/icq/user/GroupUser.java
+++ b/src/main/java/cc/moecraft/icq/user/GroupUser.java
@@ -74,6 +74,6 @@ public class GroupUser
      */
     public boolean isAdmin()
     {
-        return !getInfo().getRole().equals("member");
+        return !"member".equals(getInfo().getRole());
     }
 }


### PR DESCRIPTION
事件新增："群成员名片更新事件(go-cqhttp拓展)"、"群红包运气王事件"、"群成员荣耀变更事件"
消息组件新增："群聊戳一戳" (适配 go-cqhttp, 与 OneBot 标准有差异)
若干bug修复